### PR TITLE
enableLayerCond fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 		"watchout_production",
 		"watchout-production"
 	],
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Media Server",

--- a/upgrades.js
+++ b/upgrades.js
@@ -1,0 +1,29 @@
+module.exports = function () {
+	return [layerCondFix]
+}
+
+// (version 1.2.3 => 1.2.4) Fix layerCond implementation bug
+// If "Force to conditions set in GUI" option/checkbox in "layerCond" action is not present, set a value for it.
+// This will not break old instance configurations that may rely on the old buggy implementation.
+// Previously if no conditions were checked, the value "0" would be sent causing Watchout to revert to the ones set in the GUI.
+// Starting from v1.2.4 we send the value 2^30 to disable all conditions or the value 0 to revert to GUI conditions if "Force to conditions set in GUI" is selected
+function layerCondFix(context, config, actions, feedbacks) {
+  let changes = false;
+  for (const action of actions) {
+    if(action.action = 'layerCond') {
+      if(action.options[30] === undefined) {
+        let somethingIsSelected = false;
+        for(let i = 0; i < 30; i++) {
+          if(action.options[i] == true) {
+            somethingIsSelected = true;
+            break;
+          }
+        }
+        // If no condition is set, we activate the checkbox "Force to conditions set in GUI" to keep sending 0 as the old, bugged, implementation did
+        (somethingIsSelected) ? action.options[30] = false : action.options[30] = true;
+        changes = true;
+      }
+    }
+  }
+  return changes;
+}

--- a/watchout-production.js
+++ b/watchout-production.js
@@ -16,6 +16,14 @@ function instance(system, id, config) {
 			default: false
 		}
 	}
+	// Extra checkbox to force the use of the conditions previously set in the producer's GUI
+	this.choicesConditions[this.maxConditions] = {
+		type: 'checkbox',
+		label: 'Force to default GUI conditions',
+		id: this.maxConditions,
+		default: false
+	}
+
 	// super-constructor
 	instance_skel.apply(this, arguments);
 
@@ -329,6 +337,14 @@ instance.prototype.action = function(action) {
 				if (action.options[i] === true) {
 					cond += 2**i;
 				}
+			}
+			// To disable all conditions (no conditions are checked) the correct value to be sent is 2^30
+			if(cond == 0) {
+				cond = 2**30;
+			}
+			// A value equal to 0 tells Watchout to apply default conditions (the ones set in the producer GUI, before TCP commands)
+			if(action.options[`${this.maxConditions}`] === true) {
+				cond = 0;
 			}
 			cmd = 'enableLayerCond ' + cond +'\r\n';
 			break;

--- a/watchout-production.js
+++ b/watchout-production.js
@@ -1,5 +1,6 @@
 var tcp = require('../../tcp');
 var instance_skel = require('../../instance_skel');
+const GetUpgradeScripts = require('./upgrades');
 var debug;
 var log;
 
@@ -31,6 +32,8 @@ function instance(system, id, config) {
 
 	return self;
 }
+
+instance.GetUpgradeScripts = GetUpgradeScripts;
 
 instance.prototype.init = function() {
 	var self = this;


### PR DESCRIPTION
This PR fixes a bug in the enableLayerCond command.
Currently if all layer conditions checkboxes are unticked, the value 0 is sent instead of 2^30; this PR adds another checkbox and fixes it.

More on this:
The command "enableLayerCond 0" doesn't turn off all layer conditions (as you would expect) but instead it resets the layer conditions to the ones previously set in the producer GUI/preferences.
To really set all layer conditions to off you must send the value 2^30 (or something with all 30 least significant bits set to 0).

Some extra info:
https://forum.dataton.com/topic/1558-changing-layer-conditions-with-string-cues/